### PR TITLE
Test: Check poetry.lock

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -9,3 +9,5 @@ ruff check --fix
 mypy colmi_r02_client
 
 pytest
+
+poetry check --lock


### PR DESCRIPTION
I found your `check.sh` script and figured you might be interested in adding a check for the `poetry.lock` getting out of sync with `pyproject.toml` (which should have prevented my previous PR https://github.com/tahnok/colmi_r02_client/pull/11).