### PR TITLE
fix: correct several bugs found in codebase review

### DIFF
--- a/colmi_r02_client/cli.py
+++ b/colmi_r02_client/cli.py
@@ -82,6 +82,7 @@ async def info(client: Client) -> None:
 async def get_heart_rate_log(client: Client, target: datetime) -> None:
     """Get heart rate for given date"""
 
+    target = date_utils.naive_to_aware(target)
     async with client:
         log = await client.get_heart_rate_log(target)
         print("Data:", log)
@@ -170,7 +171,9 @@ async def get_steps(client: Client, when: datetime | None = None, as_csv: bool =
     """Get step data"""
 
     if when is None:
-        when = datetime.now(tz=timezone.utc)
+        when = date_utils.now()
+    else:
+        when = date_utils.naive_to_aware(when)
     async with client:
         result = await client.get_steps(when)
         if isinstance(result, steps.NoData):
@@ -247,6 +250,7 @@ async def sync(client: Client, db_path: Path | None, start: datetime | None, end
 
     Currently grabs:
         - heart rates
+        - sport details (steps, calories, distance)
     """
 
     if db_path is None:
@@ -325,7 +329,7 @@ async def scan(all: bool) -> None:
         click.echo("-" * 44)
         for d in devices:
             name = d.name
-            if name and (all or any(name for p in DEVICE_NAME_PREFIXES if name.startswith(p))):
-                click.echo(f"{name:>20}  |  {d.address}")
+            if all or (name and any(name.startswith(p) for p in DEVICE_NAME_PREFIXES)):
+                click.echo(f"{name or '':>20}  |  {d.address}")
     else:
         click.echo("No devices found. Try moving the ring closer to computer")

--- a/colmi_r02_client/client.py
+++ b/colmi_r02_client/client.py
@@ -113,6 +113,9 @@ class Client:
                 self.queues[packet_type].put_nowait(result)
             else:
                 logger.debug(f"No result returned from parser for {packet_type}")
+        elif packet_type in self.queues:
+            # a raw command asked to receive replies for this packet type
+            self.queues[packet_type].put_nowait(packet)
         else:
             logger.warning(f"Did not expect this packet: {packet}")
 
@@ -139,8 +142,10 @@ class Client:
 
         valid_readings: list[int] = []
         error = False
-        tries = 0
-        while len(valid_readings) < 6 and tries < 20:
+        # the ring streams readings roughly once a second, sending 0 until the
+        # sensor locks on, so wait on wall clock time instead of packet count
+        deadline = asyncio.get_running_loop().time() + 40
+        while len(valid_readings) < 6 and asyncio.get_running_loop().time() < deadline:
             try:
                 data: real_time.Reading | real_time.ReadingError = await asyncio.wait_for(
                     self.queues[real_time.CMD_START_REAL_TIME].get(),
@@ -152,7 +157,7 @@ class Client:
                 if data.value != 0:
                     valid_readings.append(data.value)
             except TimeoutError:
-                tries += 1
+                pass
 
         await self.send_packet(stop_packet)
         if error:
@@ -232,13 +237,16 @@ class Client:
         await self.send_packet(reboot.REBOOT_PACKET)
 
     async def raw(self, command: int, subdata: bytearray, replies: int = 0) -> list[bytearray]:
+        # commands without a registered handler need a queue so _handle_tx can deliver replies
+        queue = self.queues.setdefault(command, asyncio.Queue())
+
         p = packet.make_packet(command, subdata)
         await self.send_packet(p)
 
         results = []
         while replies > 0:
             data: bytearray = await asyncio.wait_for(
-                self.queues[command].get(),
+                queue.get(),
                 timeout=2,
             )
             results.append(data)

--- a/colmi_r02_client/db.py
+++ b/colmi_r02_client/db.py
@@ -165,6 +165,7 @@ def _add_heart_rate(sync: Sync, ring: Ring, data: FullData, session: Session) ->
         existing = {}
         for heart_rate in session.scalars(
             select(HeartRate)
+            .where(HeartRate.ring_id == ring.ring_id)
             .where(HeartRate.timestamp >= start_of_day(log.timestamp))
             .where(HeartRate.timestamp <= end_of_day(log.timestamp))
         ):
@@ -198,6 +199,7 @@ def _add_sport_details(sync: Sync, ring: Ring, data: FullData, session: Session)
     existing_sport_logs = {}
     for sport_detail_record in session.scalars(
         select(SportDetail)
+        .where(SportDetail.ring_id == ring.ring_id)
         .where(SportDetail.timestamp >= start_of_day(start))
         .where(SportDetail.timestamp <= end_of_day(end))
     ):

--- a/colmi_r02_client/hr.py
+++ b/colmi_r02_client/hr.py
@@ -94,6 +94,9 @@ class HeartRateLogParser:
             self.reset()
             return result
         if sub_type == 0:
+            # first packet of a new log, drop any state left over from an
+            # earlier log that never completed (e.g. a timed out request)
+            self.reset()
             self.end = False
             self.size = packet[2]  # number of expected packets
             self.range = packet[3]

--- a/colmi_r02_client/packet.py
+++ b/colmi_r02_client/packet.py
@@ -12,7 +12,7 @@ def make_packet(command: int, sub_data: bytearray | None = None) -> bytearray:
     packet[0] = command
 
     if sub_data:
-        assert len(sub_data) <= 14, "Sub data must be less than 14 bytes"
+        assert len(sub_data) <= 14, "Sub data must be 14 bytes or less"
         for i in range(len(sub_data)):
             packet[i + 1] = sub_data[i]
 

--- a/colmi_r02_client/pretty_print.py
+++ b/colmi_r02_client/pretty_print.py
@@ -7,6 +7,8 @@ import dataclasses
 
 
 def print_lists(rows: list[list[Any]], header: bool = False) -> str:
+    if not rows:
+        return ""
     widths = [0] * len(rows[0])
     for row in rows:
         for i, col in enumerate(row):
@@ -27,6 +29,8 @@ def print_lists(rows: list[list[Any]], header: bool = False) -> str:
 
 
 def print_dicts(rows: list[dict]) -> str:
+    if not rows:
+        return ""
     lists = [list(rows[0].keys())]
     lists.extend(list(x.values()) for x in rows)
     return print_lists(lists, header=True)

--- a/colmi_r02_client/real_time.py
+++ b/colmi_r02_client/real_time.py
@@ -4,7 +4,7 @@ Stream real time data from the ring.
 Currently heart rate and SPO2 seem reasonable.
 
 HRV, ECG, blood pressure and blood sugar seem unlikely to be something you
-can correct
+can collect
 """
 
 from dataclasses import dataclass

--- a/colmi_r02_client/steps.py
+++ b/colmi_r02_client/steps.py
@@ -16,6 +16,9 @@ def read_steps_packet(day_offset: int = 0) -> bytearray:
     - 0x5f # less than 95 and greater than byte
     - 0x01 # constant
     """
+    if not 0 <= day_offset <= 255:
+        raise ValueError(f"day_offset must be between 0 and 255, got {day_offset}")
+
     sub_data = bytearray(b"\x00\x0f\x00\x5f\x01")
     sub_data[0] = day_offset
 
@@ -47,7 +50,7 @@ class SportDetail:
 
 
 class NoData:
-    """Returned when there's no heart rate data"""
+    """Returned when there's no step data"""
 
 
 class SportDetailParser:
@@ -75,11 +78,15 @@ class SportDetailParser:
         assert len(packet) == 16
         assert packet[0] == CMD_GET_STEP_SOMEDAY
 
-        if self.index == 0 and packet[1] == 255:
+        # 255 and 240 are not valid BCD encoded years, so it's safe to treat any
+        # packet containing them as a "no data" marker or a header respectively,
+        # even if state from an earlier log that never completed is left over
+        if packet[1] == 255:
             self.reset()
             return NoData()
 
-        if self.index == 0 and packet[1] == 240:
+        if packet[1] == 240:
+            self.reset()
             if packet[3] == 1:
                 self.new_calorie_protocol = True
             self.index += 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ import pytest
 
 
 from colmi_r02_client.client import Client
-from colmi_r02_client import battery
+from colmi_r02_client import battery, real_time
 
 MOCK_CHAR = Mock(spec=BleakGATTCharacteristic)
 
@@ -60,3 +60,53 @@ def test_handle_tx_unexpected_packet(caplog):
     client._handle_tx(MOCK_CHAR, packet)
 
     assert "Did not expect this packet:" in caplog.text
+
+
+async def test_raw_unregistered_command(monkeypatch):
+    """raw() should be able to receive replies for commands without a registered parser"""
+
+    client = Client("unused")
+    # 125 is currently unused
+    reply = bytearray(b"}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00}")
+
+    async def fake_send(_packet: bytearray) -> None:
+        client._handle_tx(MOCK_CHAR, reply)
+
+    monkeypatch.setattr(client, "send_packet", fake_send)
+
+    results = await client.raw(125, bytearray(), replies=1)
+
+    assert results == [reply]
+
+
+async def test_get_realtime_reading(monkeypatch):
+    client = Client("unused")
+
+    async def fake_send(_packet: bytearray) -> None:
+        pass
+
+    monkeypatch.setattr(client, "send_packet", fake_send)
+
+    queue = client.queues[real_time.CMD_START_REAL_TIME]
+    for value in [0, 70, 71, 72, 73, 74, 75]:
+        queue.put_nowait(real_time.Reading(kind=real_time.RealTimeReading.HEART_RATE, value=value))
+
+    result = await client.get_realtime_reading(real_time.RealTimeReading.HEART_RATE)
+
+    assert result == [70, 71, 72, 73, 74, 75]
+
+
+async def test_get_realtime_reading_error(monkeypatch):
+    client = Client("unused")
+
+    async def fake_send(_packet: bytearray) -> None:
+        pass
+
+    monkeypatch.setattr(client, "send_packet", fake_send)
+
+    queue = client.queues[real_time.CMD_START_REAL_TIME]
+    queue.put_nowait(real_time.ReadingError(kind=real_time.RealTimeReading.HEART_RATE, code=1))
+
+    result = await client.get_realtime_reading(real_time.RealTimeReading.HEART_RATE)
+
+    assert result is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -194,6 +194,39 @@ def test_sync_writes_heart_rates_once():
     assert len(logs) == 288
 
 
+def test_sync_two_rings_same_timestamps(caplog):
+    """Data from one ring must not stop another ring's data at the same timestamps from being stored"""
+
+    hrl = hr.HeartRateLog(
+        heart_rates=[80] * 288,
+        timestamp=datetime(2024, 11, 11, 11, 11, tzinfo=timezone.utc),
+        size=24,
+        index=295,
+        range=5,
+    )
+    sd = steps.SportDetail(
+        year=2024,
+        month=11,
+        day=11,
+        time_index=0,
+        calories=4200,
+        steps=6969,
+        distance=1234,
+    )
+    fd_1 = FullData(address="ring one", heart_rates=[hrl], sport_details=[[sd]])
+    fd_2 = FullData(address="ring two", heart_rates=[hrl], sport_details=[[sd]])
+    with get_db_session() as session:
+        full_sync(session, fd_1)
+        full_sync(session, fd_2)
+
+        logs = session.scalars(select(HeartRate)).all()
+        sport_details = session.scalars(select(SportDetail)).all()
+
+    assert len(logs) == 288 * 2
+    assert len(sport_details) == 2
+    assert "Inconsistent data detected!" not in caplog.text
+
+
 def test_sync_handles_inconsistent_data(caplog):
     address = "fake"
     hrl_1 = hr.HeartRateLog(

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -67,6 +67,24 @@ def test_parse_until_end():
     assert result.range == 5
 
 
+def test_parse_recovers_from_aborted_log():
+    """A log that never completed (e.g. timed out request) must not corrupt the next parse"""
+
+    parser = HeartRateLogParser()
+    for p in HEART_RATE_PACKETS[:5]:
+        parser.parse(p)
+
+    # a new request starts over from the first packet
+    for p in HEART_RATE_PACKETS[:-1]:
+        assert parser.parse(p) is None
+
+    result = parser.parse(HEART_RATE_PACKETS[-1])
+
+    assert isinstance(result, HeartRateLog)
+    assert result.size == 24
+    assert result.index == 295
+
+
 def test_parse_no_data():
     parser = HeartRateLogParser()
     result = parser.parse(

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 
-from colmi_r02_client.steps import SportDetailParser, SportDetail, NoData
+import pytest
+
+from colmi_r02_client.steps import SportDetailParser, SportDetail, NoData, read_steps_packet
 
 
 def test_parse_simple():
@@ -79,6 +81,27 @@ def test_parse_multi():
     actual = sdp.parse(packets[-1])
 
     assert actual == expected
+
+
+def test_parse_recovers_from_aborted_log():
+    """A log that never completed (e.g. timed out request) must not corrupt the next parse"""
+
+    sdp = SportDetailParser()
+    # header claiming 5 packets, but only one data packet arrives
+    assert sdp.parse(bytearray(b"C\xf0\x05\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x009")) is None
+    assert sdp.parse(bytearray(b"C#\x08\x13\x10\x00\x05\xc8\x000\x00\x1b\x00\x00\x00\xa9")) is None
+
+    # a new request starts over with a fresh header
+    assert sdp.parse(bytearray(b"C\xf0\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x005")) is None
+    r = sdp.parse(bytearray(b"C$\x10\x15\\\x00\x01y\x00\x15\x00\x10\x00\x00\x00\x87"))
+
+    assert r == [SportDetail(year=2024, month=10, day=15, time_index=92, calories=1210, steps=21, distance=16)]
+
+
+@pytest.mark.parametrize("day_offset", [-1, 256])
+def test_read_steps_packet_invalid_offset(day_offset):
+    with pytest.raises(ValueError, match="day_offset"):
+        read_steps_packet(day_offset)
 
 
 def test_no_data_parse():


### PR DESCRIPTION
- db: scope existing-record lookups in full_sync to the current ring,
  so syncing two rings into one database no longer silently drops one
  ring's heart rates and overwrites its sport details
- client: raw() no longer raises KeyError for commands without a
  registered handler; replies for such commands are now delivered to
  the caller instead of being dropped by _handle_tx
- client: bound real time polling by wall clock time so a ring that
  streams zero-value readings can't loop forever
- cli: treat naive --target/--when datetimes as UTC in
  get-heart-rate-log and get-steps, matching sync (the ring's clock is
  set in UTC)
- hr/steps: reset parser state when a new log starts so an aborted
  multi-packet parse (e.g. timed out request) can't corrupt the next one
- steps: validate day_offset range in read_steps_packet with a clear
  error instead of a cryptic bytearray failure
- cli: fix scan prefix filter expression and honor --all for unnamed
  devices
- pretty_print: return empty string for empty input instead of raising
  IndexError
- fix misleading docstrings and assert message

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012jKe5jVjWhpbaKjgfeqQby